### PR TITLE
Adding fix for transparent pngs

### DIFF
--- a/thumbor_rekognition/__init__.py
+++ b/thumbor_rekognition/__init__.py
@@ -42,7 +42,7 @@ class Detector(BaseDetector):
         """
 
         bio = BytesIO()
-        self.context.modules.engine.image.save(bio, 'JPEG')
+        self.context.modules.engine.image.convert('RGB').save(bio, 'JPEG')
         return bio.getvalue()
 
     def size(self):


### PR DESCRIPTION
The Pillow library was changed where it throws an error when you save a transparent PNG as a JPG because there was no place for the transparent channel to be mapped to in a jpg so the transparent channel is dropped. To avoid the error you need to explicitly convert the PNG to use RGB and then save it.